### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "anthonybudd/wp_cron",
+  "type": "library",
+  "authors": [
+    {
+      "name": "Anthony Budd",
+      "email": "anthonybudd94@gmail.com"
+    }
+  ],
+  "autoload": {
+    "files": ["src/WP_Cron.php"]
+  }
+}


### PR DESCRIPTION
Adds a composer.json file so the library can be included in plugins by
running `composer require anthonybudd/wp_cron`.